### PR TITLE
Switch from trollop to optimist, and use bundler 2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 PATH
   remote: .
   specs:
-    erb-hiera (0.4.3)
+    erb-hiera (0.4.4)
       hiera
-      trollop
+      optimist
 
 GEM
   remote: https://rubygems.org/
@@ -26,7 +26,7 @@ GEM
       guard (~> 2.1)
       guard-compat (~> 1.1)
       rspec (>= 2.99.0, < 4.0)
-    hiera (3.4.0)
+    hiera (3.7.0)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -37,6 +37,7 @@ GEM
     notiffany (0.1.1)
       nenv (~> 0.1)
       shellany (~> 0.0)
+    optimist (3.0.1)
     pry (0.10.4)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
@@ -62,7 +63,6 @@ GEM
     shellany (0.0.1)
     slop (3.6.0)
     thor (0.19.4)
-    trollop (2.1.2)
 
 PLATFORMS
   ruby
@@ -75,4 +75,4 @@ DEPENDENCIES
   rspec
 
 BUNDLED WITH
-   1.15.4
+   2.2.29

--- a/erb-hiera.gemspec
+++ b/erb-hiera.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.require_paths              = ["lib"]
 
   spec.add_runtime_dependency     "hiera"
-  spec.add_runtime_dependency     "trollop"
+  spec.add_runtime_dependency     "optimist"
 
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"

--- a/lib/erb-hiera/cli.rb
+++ b/lib/erb-hiera/cli.rb
@@ -1,9 +1,9 @@
-require "trollop"
+require "optimist"
 
 module ErbHiera
   module CLI
     def self.parse
-      option_parser = Trollop::Parser.new do
+      p = Optimist::Parser.new do
         opt :config,       "specify config file", :type => :string
         opt :hiera_config, "specify hiera config file", :type => :string
         opt :verbose,      "print compiled templates"
@@ -11,9 +11,9 @@ module ErbHiera
         opt :dry_run,      "don't write out files"
       end
 
-      options = Trollop.with_standard_exception_handling(option_parser) do
+      options = Optimist::with_standard_exception_handling(option_parser) do
         # show help if no cli args are provided
-        raise Trollop::HelpNeeded if ARGV.empty?
+        raise Optimist::HelpNeeded if ARGV.empty?
 
         option_parser.parse ARGV
       end

--- a/lib/erb-hiera/cli.rb
+++ b/lib/erb-hiera/cli.rb
@@ -3,7 +3,7 @@ require "optimist"
 module ErbHiera
   module CLI
     def self.parse
-      p = Optimist::Parser.new do
+      option_parser = Optimist::Parser.new do
         opt :config,       "specify config file", :type => :string
         opt :hiera_config, "specify hiera config file", :type => :string
         opt :verbose,      "print compiled templates"


### PR DESCRIPTION
Bundler updated because of running `bundle update --bundler`

Trollop is deprecated per https://rubygems.org/gems/trollop/versions/2.9.10, and I want to get rid of the following warning.

> [DEPRECATION] This gem has been renamed to optimist and will no longer be supported. Please switch to optimist as soon as possible.
